### PR TITLE
Migrate from clojure eval to babashka

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,13 @@ RUN curl -O https://download.clojure.org/install/linux-install-1.10.3.986.sh && 
     chmod +x linux-install-1.10.3.986.sh && \
     ./linux-install-1.10.3.986.sh
 
-RUN apt-get update && apt-get install -y default-jdk rlwrap
+RUN apt-get update && apt-get install -y openjdk-16-jdk rlwrap
+
+RUN curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install && \
+    chmod +x install && ./install
 
 WORKDIR /exercises-clojure
 
 COPY . .
-
-# FIXME: При первом запуске тестов clojure скачивает необходимые зависимости.
-# ВОзможно не самая лучшая команда для этого
-RUN clj -X:deps prep
 
 ENV PATH=/exercises-clojure/bin:$PATH

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,1 +1,1 @@
-clj -Sdeps '{:paths ["../../../src"]}}' -M test.clj 2>&1
+bb check-solution 2>&1

--- a/modules/10-basics/10-hello-world/bb.edn
+++ b/modules/10-basics/10-hello-world/bb.edn
@@ -1,0 +1,3 @@
+{:tasks
+ {:init (load-file "../../../src/test-helper.clj")
+  check-solution (load-file "test.clj")}}

--- a/modules/10-basics/10-hello-world/test.clj
+++ b/modules/10-basics/10-hello-world/test.clj
@@ -1,5 +1,4 @@
-(ns hello-world-test)
+(ns hello-world-test
+  (:require [test-helper :refer [assert-output]]))
 
-(load "test-helper")
-
-(assert-output "index.clj" "Hello, World!")
+(assert-output "Hello, World!")

--- a/modules/10-basics/15-prefix-notation/bb.edn
+++ b/modules/10-basics/15-prefix-notation/bb.edn
@@ -1,0 +1,3 @@
+{:tasks
+ {:init (load-file "../../../src/test-helper.clj")
+  check-solution (load-file "test.clj")}}

--- a/modules/10-basics/15-prefix-notation/test.clj
+++ b/modules/10-basics/15-prefix-notation/test.clj
@@ -1,5 +1,4 @@
-(ns prefix-notation-test)
+(ns prefix-notation-test
+  (:require [test-helper :refer [assert-output]]))
 
-(load "test-helper")
-
-(assert-output "index.clj" "-3")
+(assert-output "-3")

--- a/modules/10-basics/20-forms/bb.edn
+++ b/modules/10-basics/20-forms/bb.edn
@@ -1,0 +1,3 @@
+{:tasks
+ {:init (load-file "../../../src/test-helper.clj")
+  check-solution (load-file "test.clj")}}

--- a/modules/10-basics/20-forms/test.clj
+++ b/modules/10-basics/20-forms/test.clj
@@ -1,5 +1,4 @@
-(ns form-test)
+(ns form-test
+  (:require [test-helper :refer [assert-output]]))
 
-(load "test-helper")
-
-(assert-output "index.clj" "84")
+(assert-output "84")

--- a/modules/10-basics/25-evaluation-order/bb.edn
+++ b/modules/10-basics/25-evaluation-order/bb.edn
@@ -1,0 +1,3 @@
+{:tasks
+ {:init (load-file "../../../src/test-helper.clj")
+  check-solution (load-file "test.clj")}}

--- a/modules/10-basics/25-evaluation-order/test.clj
+++ b/modules/10-basics/25-evaluation-order/test.clj
@@ -1,5 +1,4 @@
-(ns evaluation-order-test)
+(ns evaluation-order-test
+  (:require [test-helper :refer [assert-output]]))
 
-(load "test-helper")
-
-(assert-output "index.clj" "46")
+(assert-output "46")

--- a/modules/10-basics/30-jvm-errors/bb.edn
+++ b/modules/10-basics/30-jvm-errors/bb.edn
@@ -1,0 +1,3 @@
+{:tasks
+ {:init (load-file "../../../src/test-helper.clj")
+  check-solution (load-file "test.clj")}}

--- a/modules/10-basics/30-jvm-errors/test.clj
+++ b/modules/10-basics/30-jvm-errors/test.clj
@@ -1,5 +1,4 @@
-(ns jvm-errors-test)
+(ns jvm-errors-test
+  (:require [test-helper :refer [assert-output]]))
 
-(load "test-helper")
-
-(assert-output "index.clj" "256")
+(assert-output "256")

--- a/modules/20-definitions/10-definitions-define/bb.edn
+++ b/modules/20-definitions/10-definitions-define/bb.edn
@@ -1,0 +1,3 @@
+{:tasks
+ {:init (load-file "../../../src/test-helper.clj")
+  check-solution (load-file "test.clj")}}

--- a/modules/20-definitions/10-definitions-define/test.clj
+++ b/modules/20-definitions/10-definitions-define/test.clj
@@ -1,5 +1,4 @@
-(ns define-test)
+(ns define-test
+  (:require [test-helper :refer [assert-output]]))
 
-(load "test-helper")
-
-(assert-output "index.clj" "10")
+(assert-output "10")

--- a/src/test-helper.clj
+++ b/src/test-helper.clj
@@ -1,8 +1,9 @@
-(require '[clojure.test :refer [deftest run-tests is successful?]]
-         '[clojure.string :as s])
+(ns test-helper
+  (:require [clojure.test :refer [deftest run-tests is successful?]]
+            [clojure.string :as s]))
 
-(defn ^:export assert-output [path expected]
+(defn ^:export assert-output [expected]
   (deftest solution-test
-    (let [out (s/trim (with-out-str (load-file path)))]
+    (let [out (s/trim (with-out-str (load-file "index.clj")))]
       (is (= out expected))))
-  (when-not (successful? (run-tests)) (System/exit 1)))
+  (when-not (successful? (run-tests 'test-helper)) (System/exit 1)))


### PR DESCRIPTION
Tests on native Clojure run about 25 seconds when babashka executes the same tests around 3 seconds