### PR TITLE
Specify bb version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -O https://download.clojure.org/install/linux-install-1.10.3.986.sh && 
 RUN apt-get update && apt-get install -y openjdk-16-jdk rlwrap
 
 RUN curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install && \
-    chmod +x install && ./install
+    chmod +x install && ./install --version 0.6.8
 
 WORKDIR /exercises-clojure
 


### PR DESCRIPTION
Test now are falling because of new bb version (0.7.x) with breaking changes, so in this PR early version are specified (0.6.8)